### PR TITLE
GTest Build

### DIFF
--- a/src/test/main_Test.hxx
+++ b/src/test/main_Test.hxx
@@ -1,0 +1,24 @@
+#ifndef _TEST_MAIN_TEST_HXX_
+#define _TEST_MAIN_TEST_HXX_
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+int main(int argc, char *argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+std::string TEST_get_argument(std::string arg_prefix)
+{
+    for (const auto &s : ::testing::internal::GetArgvs())
+    {
+        if (s.substr(0, arg_prefix.size()) == arg_prefix)
+        {
+            return s.substr(arg_prefix.size());
+        }
+    }
+    return "";
+}
+#endif // _TEST_MAIN_TEST_HXX_

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,0 +1,17 @@
+project(utilities C)
+set(SOURCES mustangpeak_string_helper.c)
+
+if (${GTEST})
+set(TESTS ${TESTS}
+    ${ROOT_DIR}/src/utilities/mustangpeak_string_helper_Test.cxx
+
+    PARENT_SCOPE
+)
+endif()
+
+add_library(${PROJECT_NAME} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${ROOT_DIR}/src
+)

--- a/src/utilities/mustangpeak_string_helper_Test.cxx
+++ b/src/utilities/mustangpeak_string_helper_Test.cxx
@@ -1,0 +1,34 @@
+#include "test/main_Test.hxx"
+
+#include "utilities/mustangpeak_string_helper.h"
+
+TEST(StringHelper, strnew)
+{
+    // This is a difficult test because the underlying implementation is
+    // standard malloc. Therefore it is difficult to validate the results. The
+    // following provides some sanity, but is not comprehensive.
+    char *new_str = strnew(4);
+    strcpy(new_str, "test");
+    EXPECT_EQ(0, strcmp(new_str, "test"));
+    free(new_str);
+}
+
+TEST(StringHelper, strnew_initialized)
+{
+    char *new_str = strnew_initialized(4);
+    EXPECT_EQ(new_str[0], '\0');
+    EXPECT_EQ(new_str[1], '\0');
+    EXPECT_EQ(new_str[2], '\0');
+    EXPECT_EQ(new_str[3], '\0');
+    EXPECT_EQ(new_str[4], '\0');
+    free(new_str);
+}
+
+TEST(StringHelper, strcatnew)
+{
+    std::string str1 = "str1";
+    std::string str2 = "str2";
+    char *new_str = strcatnew((char*)str1.c_str(), (char*)str2.c_str());
+    EXPECT_EQ("str1str2", std::string(new_str));
+    free(new_str);
+}

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts.
+build/

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 # Build artifacts.
 build/
+coverage.html

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.14)
+
+# Setup directory paths.
+set(ROOT_DIR ${CMAKE_SOURCE_DIR}/..)
+
+# Specify project.
+project(openlcbclib-test)
+
+# Enable the required language standards.
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Uncomment out the following line to get verbose build output.
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+# Get a copy of GoogleTest.
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# Compile flags.
+add_compile_options(
+    -fPIC -g -O0 -Wall -Werror --coverage -DGTEST -D__psv__=
+    -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Wno-attributes -D_GNU_SOURCE
+)
+# Compile flags. The "sys_common.h" include from the mla library makes an
+# improper definition of uintptr_t. This suppresses that include and works
+# around the one type dependency needed for this test build.
+add_compile_options(-D_SYS_COMMON_H -DSYS_TASKS_PRIORITY=int)
+
+# GTest and GMock includes
+include_directories(
+    ${CMAKE_SOURCE_DIR}/ ${gtest_SOURCE_DIR}/include ${gmock_SOURCE_DIR}/include
+)
+
+# Add libraries that have tests disabled.
+
+# Add libraries that have test enabled.
+set(GTEST ON)
+add_subdirectory(${ROOT_DIR}/src/utilities utilities)
+
+set(LINK_LIBS ${LINK_LIBS}
+    utilities
+)
+
+# Setup gcov target.
+add_custom_target(TARGET_GCOV ALL
+    DEPENDS gcovr/coverage.html
+)
+
+# Build an executable for each test file.
+foreach(testsourcefile ${TESTS})
+    # Manipulate path to result in unique test names.
+    get_filename_component(testname ${testsourcefile} NAME_WE)
+    get_filename_component(testdir ${testsourcefile} DIRECTORY)
+    get_filename_component(testdir ${testdir} NAME)
+    set(testname "${testdir}_${testname}")
+
+    add_executable(${testname} ${testsourcefile})
+    target_include_directories(${testname}
+        PUBLIC
+            ${ROOT_DIR}/src
+    )
+    target_link_libraries(${testname}
+        GTest::gtest_main
+        GTest::gmock_main
+
+        -fPIC
+        -lgcov
+        -lcrypto
+        -Wl,--start-group
+        ${LINK_LIBS}
+        -Wl,--end-group
+        -lavahi-client
+        -lavahi-common
+    )
+    add_custom_command(TARGET ${testname}
+        POST_BUILD
+        COMMAND ./${testname}
+        # Forces the coverage report to be regenerated if tests are run.
+        COMMAND rm -rf gcovr
+    )
+    add_dependencies(TARGET_GCOV ${testname})
+endforeach(testsourcefile ${TESTS})
+
+# Generate the HTML coverage report
+add_custom_command(OUTPUT gcovr/coverage.html
+    COMMAND mkdir -p gcovr
+    COMMAND gcovr --html-details gcovr/coverage.html --exclude=_deps.* --exclude=.*_Test.* -r ${ROOT_DIR} .
+    VERBATIM
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,8 +55,8 @@ set(END_GROUP)
 add_link_options(--coverage)
 else ()
 # Linux specific configuration
-set(START_GROUP "-wl,--start-group")
-set(END_GROUP "-wl,--end-group")
+set(START_GROUP "-Wl,--start-group")
+set(END_GROUP "-Wl,--end-group")
 set(LINK_LIBS ${LINK_LIBS}
     -lgcov
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,20 @@ set(LINK_LIBS ${LINK_LIBS}
     utilities
 )
 
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+# Mac OS X specific configuration
+set(START_GROUP)
+set(END_GROUP)
+add_link_options(--coverage)
+else ()
+# Linux specific configuration
+set(START_GROUP "-wl,--start-group")
+set(END_GROUP "-wl,--end-group")
+set(LINK_LIBS ${LINK_LIBS}
+    -lgcov
+)
+endif ()
+
 # Setup gcov target.
 add_custom_target(TARGET_GCOV ALL
     DEPENDS gcovr/coverage.html
@@ -71,13 +85,9 @@ foreach(testsourcefile ${TESTS})
         GTest::gmock_main
 
         -fPIC
-        -lgcov
-        -lcrypto
-        -Wl,--start-group
+        ${START_GROUP}
         ${LINK_LIBS}
-        -Wl,--end-group
-        -lavahi-client
-        -lavahi-common
+        ${END_GROUP}
     )
     add_custom_command(TARGET ${testname}
         POST_BUILD
@@ -92,5 +102,6 @@ endforeach(testsourcefile ${TESTS})
 add_custom_command(OUTPUT gcovr/coverage.html
     COMMAND mkdir -p gcovr
     COMMAND gcovr --html-details gcovr/coverage.html --exclude=_deps.* --exclude=.*_Test.* -r ${ROOT_DIR} .
+    COMMAND ln -sf ${CMAKE_SOURCE_DIR}/build/gcovr/coverage.html ${CMAKE_SOURCE_DIR}/
     VERBATIM
 )

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,33 @@
+JOBS ?= 5
+
+ifeq ($(OS),Windows_NT)
+ECHO  = @echo
+RM    = del /F /Q
+RMDIR = rmdir /S /Q
+else
+ECHO  = @echo
+RM    = rm -f
+RMDIR = rm -rf
+endif
+
+all: build
+	cmake --build build/ -j $(JOBS)
+
+build:
+	cmake -G "Unix Makefiles" -S . -B build/
+
+.PHONY: clean
+clean:
+	cmake --build build/ --target clean
+
+.PHONY: veryclean
+veryclean:
+	$(RMDIR) build
+
+help:
+	$(ECHO) "Usage: make [target]"
+	$(ECHO) ""
+	$(ECHO) "Targets:"
+	$(ECHO) " all        default - Generate the build/ tree, build and run all tests"
+	$(ECHO) " clean      perform a clean build, do not remove the build/ tree"
+	$(ECHO) " veryclean  remove the build/ tree and start fresh"

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,7 @@ clean:
 
 .PHONY: veryclean
 veryclean:
-	$(RMDIR) build
+	$(RMDIR) build coverage.html
 
 help:
 	$(ECHO) "Usage: make [target]"

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,39 @@
+# Tests
+The test build uses CMake to generate a build tree for tests using GTest. The CMake imports the GTest and GMock infrastructure as a dependency. A Makefile wrapper is provided to simplify the command line interface, as the CMake commands can be a bit cumbersome. For a list of the available make targets and their descriptions:
+
+`make help`
+
+The default **all** target will build the tests and run the coverage report:
+
+`make`
+
+If successful, the coverage report will be linked to **test/coverage.html** and can be viewed using any standard web browser.
+
+The GTest User's Guide can be found at https://google.github.io/googletest/.
+
+## Supported Host Platforms
+- Linux
+- Mac OS X
+
+## Dependencies
+- GNU Make
+- CMake
+- gcovr
+    - on Linux: pip3 install gcovr
+    - on Mac OX X: brew install gcovr
+
+## Adding Tests
+By convention, all test units have the **_Test.cxx** suffix on them and should be located in the same directory tree as the source under test. See **src/utilities/mustangpeak_string_helper_Test.cxx** for a simplified example. Test "helpers" uses a similar suffix convention of **_Test.hxx**. For example, see **src/test/main_Test.hxx**.
+
+To add a test, the source directly must have a **CMakeList.txt** file in it to inform the build. A good example can be found (and copied from) **/src/utilities/CMakeLists.txt**. Any dependent source files should be added to the **SOURCES** list. Each test unit should be added to the **TESTS** list. If copying an existing **CMakeLists.txt** file to a new directory, ensure that the **project** name is changed to reflect the parent directory name.
+
+When adding a new source directly to the test build, the **test/CMakeLists.txt** must also be updated by adding the subdirectory (add_subdirectory) and updating the **LINK_LIBS** with the added directory name. Search for **utilities** to see an example of the necessary additions.
+
+## GTEST Build Macro
+In some cases, it may be necessary to customize the source code under test for the test build. This should be kept to an absolute minimum. The tests are build with the predefined GTEST macro to aid this. It can be used as follows:
+
+```
+#if defined(GTEST)
+// Custom GTEST build specific stuff here.
+#endif
+```


### PR DESCRIPTION
- Adds GTest build infrastructure.
- Provides a test example in the form of a utilities test
- Provide documentation https://github.com/JimKueneman/OpenLcbCLib/blob/bakerstu-gtest-build/test/README.md
- Verified on Linux Ubuntu 24.04
- Verified on Max OS X 13.4.1